### PR TITLE
Use `golangci-lint` for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  pre-commit:
+  lint:
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
- Replace `pre-commit` with native `golangci-lint` in the CI workflow
- Update the `pre-commit` job name to `lint`