### PR TITLE
Fix `Cycle` to properly handle multiple `stop`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # it
 
 ![go](https://img.shields.io/badge/go-1.23-00ADD8?logo=go)
-![coverage](https://img.shields.io/badge/coverage-98.6%25-44CC11)
+![coverage](https://img.shields.io/badge/coverage-100.0%25-44CC11)
 
 A functional programming package based on Go 1.23+ iterators.


### PR DESCRIPTION
Since `Cycle` creates a pull iterator for every iteration over `seq`, we need to make sure to clean the relevant resources before starting the next run. We convert a single run into a closure to properly call the corresponding `stop()`.