### PR TITLE
none: fix pr title regex pattern

### DIFF
--- a/.github/.pr-title-config.json
+++ b/.github/.pr-title-config.json
@@ -11,7 +11,7 @@
   },
   "MESSAGES": {
     "success": "Passed",
-    "failure": "PR title must match: \"^(break: |feat: |fix: |none: )[\\p{Ll}\\p{Z}\\p{S}\\p{N}\\p{P}]{1,70}$\"",
+    "failure": "PR title must start with a prefix \"[break|feat|fix|none]: \" and be no more than 70 characters long.",
     "notice": ""
   }
 }


### PR DESCRIPTION
- Provide the `-u` flag for the regex pattern matching to treat the pattern as a sequence of Unicode code points
- Limit the total length to 70 characters